### PR TITLE
Review#2

### DIFF
--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -35,7 +35,7 @@ class APDS9007 {
         _enable_pin = enable_pin;
         _rload = rload;
 
-        this._points_per_read = 10.0;
+        _points_per_read = 10.0;
 
         enable(!!enable_pin);
     }

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -15,6 +15,10 @@ class APDS9007 {
     // For accurate readings time needed to wait after enabled
     static ENABLE_TIMEOUT = 5.0;
 
+    // errors
+    static ERR_SENSOR_NOT_READY = "Sensor is not ready";
+    static ERR_SENSOR_NOT_ENABLED = "Sensor is not enabled. Call enable(true) before reading.";
+
     // value of load resistor on ALS (device has current output)
     _rload              = 0.0;
     _input_pin          = null;
@@ -140,15 +144,13 @@ class APDS9007 {
 
         } else /* sensor is not enabled */ {
 
-            local message = "Sensor is not enabled. Call enable(true) before reading.";
-
             if (cb /* we're async */) {
 
                 // pass error to callback
-                imp.wakeup(0, function() { cb({err = message}); }.bindenv(this));
+                imp.wakeup(0, function() { cb({err = ERR_SENSOR_NOT_ENABLED}); }.bindenv(this));
 
             } else /* we're sync*/ {
-                throw message;
+                throw ERR_SENSOR_NOT_ENABLED;
             }
         }
 

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -78,9 +78,7 @@ class APDS9007 {
      */
     function setPointsPerReading(points) {
         // Force to a float
-        if (typeof points == "integer" || typeof points == "float") {
-            _points_per_read = points * 1.0;
-        }
+        _points_per_read = points.tofloat();
         return _points_per_read;
     }
 
@@ -136,7 +134,7 @@ class APDS9007 {
             } else /* we're sync */ {
 
                 if (ENABLE_TIMEOUT > seconds_since_enabled) {
-                    throw "Sensor is not ready";
+                    throw ERR_SENSOR_NOT_READY;
                 }
 
                 return _read();

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -81,6 +81,11 @@ class APDS9007 {
         return _points_per_read;
     }
 
+    /**
+     * Get reading
+     * Assumes that the sensor is enabled and enable timeout has passed
+     * @private
+     */
     function _read() {
         local Vpin = 0;
         local Vcc = 0;

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -118,7 +118,7 @@ class APDS9007 {
 
             if (cb /* we're async */) {
 
-                if (ENABLE_TIMEOUT < seconds_since_enabled) {
+                if (ENABLE_TIMEOUT <= seconds_since_enabled) {
                     // timeout has passed, we're good to go
                     imp.wakeup(0, function() { cb(_read()); }.bindenv(this));
                 } else {

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -84,16 +84,10 @@ class APDS9007 {
 
     /**
      * Get reading
-     * Assumes that enable timeout has passed
-     * @throws ERR_SENSOR_NOT_ENABLED
+     * Assumes that the sensor is enabled and enable timeout has passed
      * @private
      */
     function _read() {
-
-        if (!_enabled_at) {
-            throw ERR_SENSOR_NOT_ENABLED;
-        }
-
         local Vpin = 0;
         local Vcc = 0;
 
@@ -115,8 +109,8 @@ class APDS9007 {
      * Reads and returns a table with a key of brightness
      * containing the ambient light level in Lux.
      *
-     * @throws ERR_SENSOR_NOT_ENABLED
      * @throws ERR_SENSOR_NOT_READY
+     * @throws ERR_SENSOR_NOT_ENABLED
      *
      * @param {function(result)|null} cb - Callback executed on reading availability. If no callback specified, reading is returned.
      * @return {null|{brightness}}
@@ -131,10 +125,7 @@ class APDS9007 {
 
                 if (ENABLE_TIMEOUT <= seconds_since_enabled) {
                     // timeout has passed, we're good to go
-                    imp.wakeup(0, (@() {
-                        try { cb(_read()) }
-                        catch (e) { cb({err = e}) }
-                    }).bindenv(this) );
+                    imp.wakeup(0, (@() cb(_read())).bindenv(this) );
                 } else {
                     // we will be able to read once timeout passes
                     imp.wakeup(
@@ -157,10 +148,7 @@ class APDS9007 {
             if (cb /* we're async */) {
 
                 // pass error to callback
-                imp.wakeup(0, (@() {
-                    try { cb(_read()) }
-                    catch (e) { cb({err = e}) }
-                }).bindenv(this) );
+                imp.wakeup(0, (@() cb({err = ERR_SENSOR_NOT_ENABLED})).bindenv(this));
 
             } else /* we're sync*/ {
                 throw ERR_SENSOR_NOT_ENABLED;

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -100,7 +100,7 @@ class APDS9007 {
         Vpin = (Vpin / 65535.0) * Vcc;
 
         local Iout = (Vpin / _rload) * 1000000.0; // current in µA
-        result = {"brightness" : math.pow(10.0, (Iout / 10.0))};
+        return {"brightness" : math.pow(10.0, (Iout / 10.0))};
     }
 
     /**

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -122,7 +122,7 @@ class APDS9007 {
 
                 if (ENABLE_TIMEOUT <= seconds_since_enabled) {
                     // timeout has passed, we're good to go
-                    imp.wakeup(0, (@() cb(_read()).bindenv(this));
+                    imp.wakeup(0, (@() cb(_read())).bindenv(this) );
                 } else {
                     // we will be able to read once timeout passes
                     imp.wakeup(

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -34,10 +34,10 @@ class APDS9007 {
         _input_pin = input_pin;
         _enable_pin = enable_pin;
         _rload = rload;
-        _enabled = _als_en ? false : true;
 
         this._points_per_read = 10.0;
 
+        enable(!!enable_pin);
     }
 
     /**

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -108,8 +108,8 @@ class APDS9007 {
      * Reads and returns a table with a key of brightness
      * containing the ambient light level in Lux.
      *
-     * @param {function(result)|null} cb - callback executed on reading availability
-     * @return {null|{read}
+     * @param {function(result)|null} cb - Callback executed on reading availability. If no callback specified, reading is rejturned
+     * @return {null|{brightness}}
      */
     function read(cb = null) {
 

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -107,7 +107,7 @@ class APDS9007 {
      * Reads and returns a table with a key of brightness
      * containing the ambient light level in Lux.
      *
-     * @param {function(result)|null} cb - Callback executed on reading availability. If no callback specified, reading is rejturned
+     * @param {function(result)|null} cb - Callback executed on reading availability. If no callback specified, reading is returned.
      * @return {null|{brightness}}
      */
     function read(cb = null) {

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -125,7 +125,8 @@ class APDS9007 {
 
                 if (ENABLE_TIMEOUT <= seconds_since_enabled) {
                     // timeout has passed, we're good to go
-                    imp.wakeup(0, (@() cb(_read())).bindenv(this) );
+                    local reading = _read();
+                    imp.wakeup(0, (@() cb(reading)).bindenv(this) );
                 } else {
                     // we will be able to read once timeout passes
                     imp.wakeup(

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -124,7 +124,7 @@ class APDS9007 {
                 } else {
                     // we will be able to read once timeout passes
                     imp.wakeup(
-                        ENABLE_TIMEOUT - seconds_since_enabled + 0.1 /* compensate for timer inaccuracy */,
+                        ENABLE_TIMEOUT - seconds_since_enabled,
                         (@() read(cb)).bindenv(this)
                     );
                 }

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -140,7 +140,7 @@ class APDS9007 {
 
         } else /* sensor is not enabled */ {
 
-            local message = "Sensor is not enabled. Call enable(true) before reading";
+            local message = "Sensor is not enabled. Call enable(true) before reading.";
 
             if (cb /* we're async */) {
 

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -17,25 +17,27 @@ class APDS9007 {
 
     // value of load resistor on ALS (device has current output)
     _rload              = 0.0;
-    _als_pin            = null;
-    _als_en             = false;
+    _input_pin          = null;
+    _enable_pin         = null;
 
     _points_per_read    = 0.0;
     _enable_flag        = false;
     _enabled            = false;
 
     /**
-     * @param {Pin} als_pin - analog input pin
+     * @param {Pin} input_pin - analog input pin
      * @param {float} rload - value of load resistor on ALS (device has current output)
-     * @param {bool} als_en - sensor enable flag
+     * @param {Pin} enable_pin - enable pin
      */
-    constructor(als_pin, rload, als_en = false) {
-        _als_pin = als_pin;
-        _als_en = als_en;
-        _rload = rload;
+    constructor(input_pin, rload, enable_pin = null) {
 
+        _input_pin = input_pin;
+        _enable_pin = enable_pin;
+        _rload = rload;
         _enabled = _als_en ? false : true;
-        _points_per_read = 10.0;
+
+        this._points_per_read = 10.0;
+
     }
 
     /**
@@ -48,16 +50,16 @@ class APDS9007 {
      * @return {null}
      */
     function enable(state = true) {
-        if (_als_en && state) {
-            _als_en.write(1);
+        if (_enable_pin && state) {
+            _enable_pin.write(1);
             _enable_flag = true;
             imp.wakeup(ENABLE_TIMEOUT, function() {
                 _enabled = true;
                 _enable_flag = false;
             }.bindenv(this))
         }
-        if (_als_en && !state) {
-            _als_en.write(0);
+        if (_enable_pin && !state) {
+            _enable_pin.write(0);
             _enabled = false;
         }
     }
@@ -102,7 +104,7 @@ class APDS9007 {
 
             // average several readings for improved precision
             for (local i = 0; i < _points_per_read; i++) {
-                Vpin += _als_pin.read();
+                Vpin += _input_pin.read();
                 Vcc += hardware.voltage();
             }
 

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -20,7 +20,7 @@ class APDS9007 {
     _input_pin          = null;
     _enable_pin         = null;
 
-    _points_per_read    = 0.0;
+    _points_per_read    = 10.0;
     _enable_flag        = false;
     _enabled            = false;
 
@@ -30,13 +30,9 @@ class APDS9007 {
      * @param {Pin} enable_pin - enable pin
      */
     constructor(input_pin, rload, enable_pin = null) {
-
         _input_pin = input_pin;
         _enable_pin = enable_pin;
         _rload = rload;
-
-        _points_per_read = 10.0;
-
         enable(!!enable_pin);
     }
 

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -122,7 +122,7 @@ class APDS9007 {
 
                 if (ENABLE_TIMEOUT <= seconds_since_enabled) {
                     // timeout has passed, we're good to go
-                    imp.wakeup(0, function() { cb(_read()); }.bindenv(this));
+                    imp.wakeup(0, (@() cb(_read()).bindenv(this));
                 } else {
                     // we will be able to read once timeout passes
                     imp.wakeup(
@@ -145,7 +145,7 @@ class APDS9007 {
             if (cb /* we're async */) {
 
                 // pass error to callback
-                imp.wakeup(0, function() { cb({err = ERR_SENSOR_NOT_ENABLED}); }.bindenv(this));
+                imp.wakeup(0, (@() cb({err = ERR_SENSOR_NOT_ENABLED})).bindenv(this));
 
             } else /* we're sync*/ {
                 throw ERR_SENSOR_NOT_ENABLED;

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -34,7 +34,6 @@ class APDS9007 {
         _input_pin = input_pin;
         _enable_pin = enable_pin;
         _rload = rload;
-        enable(!!enable_pin);
     }
 
     /**

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -10,7 +10,7 @@
  */
 class APDS9007 {
 
-    static version = [2,0,0];
+    static version = [2, 0, 0];
 
     // For accurate readings time needed to wait after enabled
     static ENABLE_TIMEOUT = 5.0;
@@ -124,9 +124,10 @@ class APDS9007 {
                     imp.wakeup(0, function() { cb(_read()); }.bindenv(this));
                 } else {
                     // we will be able to read once timeout passes
-                    imp.wakeup(ENABLE_TIMEOUT - seconds_since_enabled, function () {
-                        read(cb);
-                    }.bindenv(this));
+                    imp.wakeup(
+                        ENABLE_TIMEOUT - seconds_since_enabled + 0.1 /* compensate for timer inaccuracy */,
+                        (@() read(cb)).bindenv(this)
+                    );
                 }
 
             } else /* we're sync */ {

--- a/APDS9007.class.nut
+++ b/APDS9007.class.nut
@@ -141,13 +141,15 @@ class APDS9007 {
 
         } else /* sensor is not enabled */ {
 
+            local message = "Sensor is not enabled. Call enable(true) before reading";
+
             if (cb /* we're async */) {
 
                 // pass error to callback
-                imp.wakeup(0, function() { cb({err = "Sensor is not enabled. Call enable(true) before reading"}); }.bindenv(this));
+                imp.wakeup(0, function() { cb({err = message}); }.bindenv(this));
 
             } else /* we're sync*/ {
-                throw "Sensor is not enabled. Call enable(true) before reading"
+                throw message;
             }
         }
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ lightsensor.read(function(result) {
 });
 ```
 
-Note If an error occured during the read, an err key will be present in the data – you should always check for the existance of the err key before using the results.
+Note If an error occured during the read in _asynchronous_ mode, an err key will be present in the data – you should always check for the existance of the err key before using the results. In _synchronous_ mode an exception will be thrown in case of error. 
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The APDS9007 should be connected as follows:
 
 ### Constructor
 
-To instantiate a new APDS9007 object, you need to pass in the configured analog input pin the sensor is connected to, the value of the load resistor, and an optional configured digital output enable pin.
+To instantiate a new APDS9007 object, you need to pass in the configured analog input pin the sensor is connected to, the value of the load resistor, and a configured digital output enable pin.
 
 ```squirrel
 const RLOAD = 47000.0
@@ -82,31 +82,33 @@ Note If an error occured during the read, an err key will be present in the data
 // value of load resistor on ALS
 const RLOAD = 47000.0;
 
-// use pin#5 as analog in
+// use pin#5 as analog input
 analogInputPin <- hardware.pin5;
 analogInputPin.configure(ANALOG_IN);
 
-// use pin#7 as enable pin
+// use pin#7 as enable poin
 enablePin <- hardware.pin7;
 enablePin.configure(DIGITAL_OUT, 0);
 
 // initialize driver class
-lightsensor <- APDS9007(analogInputPin, RLOAD, enablePin);
+lightsensor <- APDS9007(analogInputPin, 47000 , enablePin);
 
 // enable sensor
 lightsensor.enable(true);
 
 // get readout
-readLightLevel <- @() lightsensor.read(function(result) {
-    if ("err" in result) {
-        server.log("Error Reading APDS9007: " + result.err);
-        return;
-    }
-    server.log("Light level = " + result.brightness + " Lux");
-    imp.wakeup(2, readLightLevel); // repeat in 2 seconds
-});
+function readLightLevel() {
+    lightsensor.read(function (result) {
+        if ("err" in result) {
+            server.log("Error Reading APDS9007: " + result.err);
+            return;
+        }
+        server.log("Light level = " + result.brightness + " Lux");
+        imp.wakeup(2, readLightLevel); // repeat in 2 seconds
+    });
+};
 
-// start reading light level every 2 seconds
+// start reading light level every 2 seconds, the first reading will arrive in 5 secs
 readLightLevel();
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,18 +80,18 @@ Note If an error occured during the read, an err key will be present in the data
 #require "APDS9007.class.nut:2.0.0"
 
 // value of load resistor on ALS
-const RLOAD = 47000.0
+const RLOAD = 47000.0;
 
 // use pin#5 as analog in
-analogInputPin <- hardware.pin5
-analogInputPin.configure(ANALOG_IN)
+analogInputPin <- hardware.pin5;
+analogInputPin.configure(ANALOG_IN);
 
 // use pin#7 as digital out
-enablePin <- hardware.pin7
-enablePin.configure(DIGITAL_OUT, 0)
+enablePin <- hardware.pin7;
+enablePin.configure(DIGITAL_OUT, 0);
 
 // initialize driver class
-lightsensor <- APDS9007(analogInputPin, RLOAD, enablePin)
+lightsensor <- APDS9007(analogInputPin, RLOAD, enablePin);
 
 // enable sensor
 lightsensor.enable(true);

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ const RLOAD = 47000.0;
 analogInputPin <- hardware.pin5;
 analogInputPin.configure(ANALOG_IN);
 
-// use pin#7 as digital out
+// use pin#7 as enable pin
 enablePin <- hardware.pin7;
 enablePin.configure(DIGITAL_OUT, 0);
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ lightsensor.read(function(result) {
 });
 ```
 
-Note If an error occured during the read in _asynchronous_ mode, an err key will be present in the data – you should always check for the existance of the err key before using the results. In _synchronous_ mode an exception will be thrown in case of error. 
+Note If an error occured during the read in _asynchronous_ mode, an err key will be present in the data – you should always check for the existance of the err key before using the results. In _synchronous_ mode an exception will be thrown in case of error.
 
 ## Example
 
@@ -91,7 +91,7 @@ enablePin <- hardware.pin7;
 enablePin.configure(DIGITAL_OUT, 0);
 
 // initialize driver class
-lightsensor <- APDS9007(analogInputPin, 47000 , enablePin);
+lightsensor <- APDS9007(analogInputPin, RLOAD , enablePin);
 
 // enable sensor
 lightsensor.enable(true);

--- a/example-a.nut
+++ b/example-a.nut
@@ -3,29 +3,31 @@
 // value of load resistor on ALS
 const RLOAD = 47000.0;
 
-// use pin#5 as analog in
+// use pin#5 as analog input
 analogInputPin <- hardware.pin5;
 analogInputPin.configure(ANALOG_IN);
 
-// use pin#7 as enable pin
+// use pin#7 as enable poin
 enablePin <- hardware.pin7;
 enablePin.configure(DIGITAL_OUT, 0);
 
 // initialize driver class
-lightsensor <- APDS9007(analogInputPin, RLOAD, enablePin);
+lightsensor <- APDS9007(analogInputPin, 47000 , enablePin);
 
 // enable sensor
 lightsensor.enable(true);
 
 // get readout
-readLightLevel <- @() lightsensor.read(function(result) {
-    if ("err" in result) {
-        server.log("Error Reading APDS9007: " + result.err);
-        return;
-    }
-    server.log("Light level = " + result.brightness + " Lux");
-    imp.wakeup(2, readLightLevel); // repeat in 2 seconds
-});
+function readLightLevel() {
+    lightsensor.read(function (result) {
+        if ("err" in result) {
+            server.log("Error Reading APDS9007: " + result.err);
+            return;
+        }
+        server.log("Light level = " + result.brightness + " Lux");
+        imp.wakeup(2, readLightLevel); // repeat in 2 seconds
+    });
+};
 
-// start reading light level every 2 seconds
+// start reading light level every 2 seconds, the first reading will arrive in 5 secs
 readLightLevel();

--- a/example-a.nut
+++ b/example-a.nut
@@ -7,7 +7,7 @@ const RLOAD = 47000.0;
 analogInputPin <- hardware.pin5;
 analogInputPin.configure(ANALOG_IN);
 
-// use pin#7 as digital out
+// use pin#7 as enable pin
 enablePin <- hardware.pin7;
 enablePin.configure(DIGITAL_OUT, 0);
 

--- a/example-a.nut
+++ b/example-a.nut
@@ -12,7 +12,7 @@ enablePin <- hardware.pin7;
 enablePin.configure(DIGITAL_OUT, 0);
 
 // initialize driver class
-lightsensor <- APDS9007(analogInputPin, 47000 , enablePin);
+lightsensor <- APDS9007(analogInputPin, RLOAD , enablePin);
 
 // enable sensor
 lightsensor.enable(true);

--- a/example-a.nut
+++ b/example-a.nut
@@ -1,18 +1,18 @@
 #require "APDS9007.class.nut:2.0.0"
 
 // value of load resistor on ALS
-const RLOAD = 47000.0
+const RLOAD = 47000.0;
 
 // use pin#5 as analog in
-analogInputPin <- hardware.pin5
-analogInputPin.configure(ANALOG_IN)
+analogInputPin <- hardware.pin5;
+analogInputPin.configure(ANALOG_IN);
 
 // use pin#7 as digital out
-enablePin <- hardware.pin7
-enablePin.configure(DIGITAL_OUT, 0)
+enablePin <- hardware.pin7;
+enablePin.configure(DIGITAL_OUT, 0);
 
 // initialize driver class
-lightsensor <- APDS9007(analogInputPin, RLOAD, enablePin)
+lightsensor <- APDS9007(analogInputPin, RLOAD, enablePin);
 
 // enable sensor
 lightsensor.enable(true);


### PR DESCRIPTION
- Refactoring for more streamlined internal logic, readability, explanatory variable naming
- Made _enable_pin_ required, since the rest of the logic assumes enabling is handled internally
- Errors are now thrown in _sync_ mode according to our sensor libraries guidelines
